### PR TITLE
Replace beta chlamydia link with www.nhs.uk link

### DIFF
--- a/app/views/start.nunjucks
+++ b/app/views/start.nunjucks
@@ -16,7 +16,7 @@
 
 <div class="reading-width">
   <p class="nhsuk-page-intro">
-    <div>The only way to know if you have <a href="https://beta.nhs.uk/conditions/chlamydia/about/">chlamydia</a> is to get tested.</div>
+    <div>The only way to know if you have <a href="https://www.nhs.uk/conditions/chlamydia/">chlamydia</a> is to get tested.</div>
 
     <p>This service can help you:</p>
 


### PR DESCRIPTION
The beta.nhs.uk page is being removed and will redirect to www.nhs.uk.
This change removes the extra redirect hop.