### PR TITLE
add cookie policy link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.24.0 / 2019-09-26
+===================
+- Add footer link to beta cookie policy page 
+- Change chlamydia content link from beta to nhs.uk
+
 0.23.0 / TBC
 ===================
 - Enable deployment to Production via DevOps

--- a/app/views/includes/footer.nunjucks
+++ b/app/views/includes/footer.nunjucks
@@ -16,6 +16,7 @@
         <li><a href="https://www.nhs.uk/about-us/sitemap/">Sitemap</a></li>
         <li><a href="https://www.nhs.uk/accessibility/">Accessibility</a></li>
         <li><a href="https://www.nhs.uk/our-policies/">Our policies</a></li>
+        <li><a href="https://beta.nhs.uk/our-policies/cookies-policy/">Cookie policy</a></li>
         <li>&copy; Crown Copyright</li>
       </ul>
     </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sexual-health-service-finder",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Helping to connect people to sexual health services.",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Add a link in the footer to beta cookies page to allow users to manage cookies on the beta domain